### PR TITLE
Fix stats width

### DIFF
--- a/src/components/ExpandableCard.js
+++ b/src/components/ExpandableCard.js
@@ -21,7 +21,7 @@ class ExpandableCard extends Component {
     };
 
     static defaultProps = {
-        width: 400,
+        width: "max-content",
         margin: '0 auto',
         style: {},
         defaultCardData: {},

--- a/src/components/ResonatorStats.js
+++ b/src/components/ResonatorStats.js
@@ -83,17 +83,17 @@ class ResonatorStats extends Component {
 
     renderCard(question) {
         return (
-            <div key={question.id} className='row' style={{marginBottom: 10}}>
-                <ExpandableCard
-                    id={`resonatorStats_${question.id}`}
-                    title={question.title}
-                    subtitle={question.description}
-                    avatar={<InsertChart/>}
-                >
-                    {_.isEmpty(question.followerAnswers) ?
-                        this.renderEmptyState() : this.renderChart(question)}
-                </ExpandableCard>
-            </div>
+            <ExpandableCard
+                id={`resonatorStats_${question.id}`}
+                title={question.title}
+                subtitle={question.description}
+                avatar={<InsertChart/>}
+                key={question.id}
+                style={{marginBottom: 10}}
+            >
+                {_.isEmpty(question.followerAnswers) ?
+                    this.renderEmptyState() : this.renderChart(question)}
+            </ExpandableCard>
         )
     }
 

--- a/src/components/ShowResonator.js
+++ b/src/components/ShowResonator.js
@@ -30,11 +30,11 @@ class ShowResonator extends Component {
 
     renderSectionTitle(title) {
         return (
-            <div style={{ marginBottom: 10 }}>
+            <div style={{ marginBottom: 20 }}>
                 <Typography variant="h5" style={{ textAlign: "center" }}>
                     {title}
                 </Typography>
-                <Divider />
+                <Divider style={{ margin: 10 }} />
             </div>
         );
     }
@@ -47,12 +47,7 @@ class ShowResonator extends Component {
         let resonatorId = this.props.match.params.resonatorId;
 
         return (
-            <div
-                style={{
-                    // height: "100%",
-                    marginTop: 36,
-                }}
-            >
+            <div style={{ margin: 30 }}>
                 {this.renderSectionTitle(this.props.resonator.title)}
                 <div>
                     <ExpandableCard
@@ -85,14 +80,12 @@ class ShowResonator extends Component {
                         </div>
                     </ExpandableCard>
                 </div>
-                <div style={{ marginTop: 30 }}>
-                    {_.size(this.props.resonator.questions) > 0 && (
-                        <div>
-                            {this.renderSectionTitle("Criteria")}
-                            <ResonatorStats resonatorId={this.props.match.params.resonatorId} />
-                        </div>
-                    )}
-                </div>
+                {_.size(this.props.resonator.questions) > 0 && (
+                    <div style={{ marginTop: 40 }}>
+                        {this.renderSectionTitle("Criteria")}
+                        <ResonatorStats resonatorId={this.props.match.params.resonatorId} />
+                    </div>
+                )}
             </div>
         );
     }


### PR DESCRIPTION
Expandable cards had a default fixed width which was pretty small.
It should now expand with its content.

Note: I couldn't test it on actual graphs because I don't have such data in my DB.
I have tested it with a long mock text, which displayed as desired.