### PR TITLE
Feature/follower ui improvements

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -49,7 +49,7 @@ const leaderGroupRoutes = [
 ];
 
 const followerRoutes = [
-    { path: "/follower/resonators/:sentResonatorId?", component: ResonatorsOverview, exact: false },
+    { path: "/follower/resonators/:sentResonatorId?", component: ResonatorsOverview },
 ];
 
 const commonRoutes = [

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -18,7 +18,6 @@ import EditResonator from "./EditResonator";
 import ResetPassword from "./ResetPassword";
 import ResonatorStats from "./ResonatorStats";
 import ResonatorFeedback from "./ResonatorFeedback";
-import SentResonator from "./followers/SentResonator";
 import FollowerResonators from "./FollowerResonators";
 import FollowerGroupResonators from './FollowerGroupResonators';
 import FollowerGroupMembers from './FollowerGroupMembers';
@@ -40,18 +39,17 @@ const leaderRoutes = [
 ];
 
 const leaderGroupRoutes = [
-    { path: "/followerGroups/:followerGroupId/resonators/new", component: EditResonator},
-    { path: "/followerGroups/:followerGroupId/resonators/:resonatorId/edit", component: EditResonator},
-    { path: "/followerGroups/:followerGroupId/resonators/:resonatorId/stats/:qid", component: ResonatorStats},
-    { path: "/followerGroups/:followerGroupId/resonators/:resonatorId", component: ShowResonator},
-    { path: "/followerGroups/:followerGroupId/members", component: FollowerGroupMembers},
-    { path: "/followerGroups/:followerGroupId/resonators", component: FollowerGroupResonators},
-    { path: "/followerGroups", component: FollowerGroups},
+    { path: "/followerGroups/:followerGroupId/resonators/new", component: EditResonator },
+    { path: "/followerGroups/:followerGroupId/resonators/:resonatorId/edit", component: EditResonator },
+    { path: "/followerGroups/:followerGroupId/resonators/:resonatorId/stats/:qid", component: ResonatorStats },
+    { path: "/followerGroups/:followerGroupId/resonators/:resonatorId", component: ShowResonator },
+    { path: "/followerGroups/:followerGroupId/members", component: FollowerGroupMembers },
+    { path: "/followerGroups/:followerGroupId/resonators", component: FollowerGroupResonators },
+    { path: "/followerGroups", component: FollowerGroups },
 ];
 
 const followerRoutes = [
-    { path: "/follower/resonators", component: ResonatorsOverview },
-    { path: "/follower/resonators/:sentResonatorId", component: SentResonator },
+    { path: "/follower/resonators/:sentResonatorId?", component: ResonatorsOverview, exact: false },
 ];
 
 const commonRoutes = [

--- a/src/components/followers/ResonatorQuestions.js
+++ b/src/components/followers/ResonatorQuestions.js
@@ -37,7 +37,8 @@ export default ({ resonator, setResonator, showError }) => {
     useEffect(() => setActiveQuestion(findFirstUnansweredQuestion(resonator)), []);
 
     const stepBack = () => setActiveQuestion((prevActiveQuestion) => prevActiveQuestion - 1);
-    const stepNext = () => setActiveQuestion((prevActiveQuestion) => prevActiveQuestion + 1);
+    const stepNext = () =>
+        setActiveQuestion((prevActiveQuestion) => Math.min(prevActiveQuestion + 1, resonator.questions.length - 1));
 
     const answerQuestion = (resonatorQuestion) => (event) => {
         fetcher
@@ -48,6 +49,7 @@ export default ({ resonator, setResonator, showError }) => {
             .then((data) => data.resonator)
             .then(setResonator)
             .then(confirmSave)
+            .then(() => !resonatorQuestion.answer && stepNext())
             .catch(showError);
     };
 

--- a/src/components/followers/ResonatorsOverview.js
+++ b/src/components/followers/ResonatorsOverview.js
@@ -1,8 +1,10 @@
+import { useParams } from "react-router";
 import React, { useState, useEffect } from "react";
 import { Typography, makeStyles } from "@material-ui/core";
 
 import fetcher from "../../api/fetcher";
 import ResonatorList from "./ResonatorList";
+import SentResonator from "./SentResonator";
 import LoadMoreButton from "./LoadMoreButton";
 import LoadingOverlay from "./LoadingOverlay";
 
@@ -19,6 +21,7 @@ export default function ResonatorsOverview() {
     const [page, setPages] = useState(0);
 
     const classes = useStyles();
+    const { sentResonatorId } = useParams();
 
     useEffect(() => {
         setLoading(true);
@@ -30,7 +33,9 @@ export default function ResonatorsOverview() {
             .finally(() => setLoading(false));
     }, [page]);
 
-    return (
+    return sentResonatorId ? (
+        <SentResonator sentResonatorId={sentResonatorId} />
+    ) : (
         <>
             {!resonators.length ? <LoadingOverlay loading={loading} /> : null}
             <ResonatorList

--- a/src/components/followers/SentResonator.js
+++ b/src/components/followers/SentResonator.js
@@ -10,7 +10,6 @@ import {
     CardContent,
     CardActions,
     Divider,
-    Link,
     Typography,
     Grow,
     Button,
@@ -31,6 +30,12 @@ const useStyles = makeStyles((theme) => ({
     },
     link: {
         textTransform: "none",
+        maxWidth: "100%",
+    },
+    linkLabel: {
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        textOverflow: "ellipsis",
     },
 }));
 
@@ -127,26 +132,28 @@ export default function SentResonator() {
     );
 }
 
-const ResonatorBody = ({ resonator }) => (
-    <>
-        <Direction by={resonator.content}>
-            <Typography paragraph>{resonator.content}</Typography>
-        </Direction>
-        {resonator.link ? (
-            <Typography>
+const ResonatorBody = ({ resonator }) => {
+    const classes = useStyles();
+
+    return (
+        <>
+            <Direction by={resonator.content}>
+                <Typography paragraph>{resonator.content}</Typography>
+            </Direction>
+            {resonator.link ? (
                 <Button
                     size="small"
                     color="primary"
                     variant="outlined"
                     startIcon={<LinkIcon />}
-                    className={useStyles().link}
+                    className={classes.link}
                     href={resonator.link}
                     rel="noreferrer"
                     target="_blank"
                 >
-                    {resonator.link}
+                    <span className={classes.linkLabel}>{resonator.link}</span>
                 </Button>
-            </Typography>
-        ) : null}
-    </>
-);
+            ) : null}
+        </>
+    );
+};

--- a/src/components/followers/SentResonator.js
+++ b/src/components/followers/SentResonator.js
@@ -1,7 +1,7 @@
 import { useSnackbar } from "notistack";
-import { useParams } from "react-router";
 import React, { useEffect, useState } from "react";
-import { Link as LinkIcon } from "@material-ui/icons";
+import { useParams, useHistory } from "react-router";
+import { Link as LinkIcon, Close } from "@material-ui/icons";
 import {
     makeStyles,
     Card,
@@ -13,6 +13,7 @@ import {
     Typography,
     Grow,
     Button,
+    IconButton,
 } from "@material-ui/core";
 
 import Direction from "../Direction";
@@ -23,6 +24,9 @@ import ResonatorQuestions from "./ResonatorQuestions";
 import { formatResonatorTime } from "./utils";
 
 const useStyles = makeStyles((theme) => ({
+    root: {
+        position: "relative",
+    },
     media: {
         height: 200,
         margin: theme.spacing(2, 0),
@@ -37,10 +41,18 @@ const useStyles = makeStyles((theme) => ({
         whiteSpace: "nowrap",
         textOverflow: "ellipsis",
     },
+    backButton: {
+        position: "absolute",
+        right: 0,
+        transform: "translate(50%, -50%)",
+        backgroundColor: theme.palette.background.paper,
+        boxShadow: theme.shadows[1],
+    },
 }));
 
 export default function SentResonator() {
     const classes = useStyles();
+    const history = useHistory();
     const { sentResonatorId } = useParams();
     const { enqueueSnackbar } = useSnackbar();
 
@@ -61,6 +73,8 @@ export default function SentResonator() {
             })
         );
 
+    const goToAllResonators = () => history.push("/follower/resonators");
+
     useEffect(() => {
         setLoading(true);
         fetcher(`/follower/resonators/${sentResonatorId}`)
@@ -78,54 +92,59 @@ export default function SentResonator() {
             <LoadingOverlay loading={loading} />
             {!loading && resonator ? (
                 <Grow in>
-                    <Card>
-                        <Direction by={resonator.title}>
-                            <CardHeader
-                                title={resonator.title}
-                                subheader={formatResonatorTime(resonator.time)}
-                                titleTypographyProps={{ gutterBottom: true }}
-                            />
-                        </Direction>
-                        <Divider />
-                        <CardMedia image={resonator.picture} className={classes.media} />
-                        <Divider />
-                        <CardContent>
-                            <ResonatorBody resonator={resonator} />
-                        </CardContent>
-                        {resonator.questions.length ? (
-                            <>
-                                <Divider />
-                                <CardContent>
-                                    {editMode ? (
-                                        <ResonatorQuestions
-                                            showError={showError}
-                                            resonator={resonator}
-                                            setResonator={setResonator}
-                                        />
-                                    ) : (
-                                        <ResonatorAnswers resonator={resonator} />
-                                    )}
-                                </CardContent>
-                                <Divider />
-                                <CardActions>
-                                    {editMode ? (
-                                        <Button
-                                            color="primary"
-                                            variant="contained"
-                                            disabled={!resonator.done}
-                                            onClick={() => setEditMode(false)}
-                                        >
-                                            Finish
-                                        </Button>
-                                    ) : (
-                                        <Button color="primary" onClick={() => setEditMode(true)}>
-                                            Edit answers
-                                        </Button>
-                                    )}
-                                </CardActions>
-                            </>
-                        ) : null}
-                    </Card>
+                    <div className={classes.root}>
+                        <IconButton className={classes.backButton} size="small" onClick={goToAllResonators}>
+                            <Close />
+                        </IconButton>
+                        <Card>
+                            <Direction by={resonator.title}>
+                                <CardHeader
+                                    title={resonator.title}
+                                    subheader={formatResonatorTime(resonator.time)}
+                                    titleTypographyProps={{ gutterBottom: true }}
+                                />
+                            </Direction>
+                            <Divider />
+                            <CardMedia image={resonator.picture} className={classes.media} />
+                            <Divider />
+                            <CardContent>
+                                <ResonatorBody resonator={resonator} />
+                            </CardContent>
+                            {resonator.questions.length ? (
+                                <>
+                                    <Divider />
+                                    <CardContent>
+                                        {editMode ? (
+                                            <ResonatorQuestions
+                                                showError={showError}
+                                                resonator={resonator}
+                                                setResonator={setResonator}
+                                            />
+                                        ) : (
+                                            <ResonatorAnswers resonator={resonator} />
+                                        )}
+                                    </CardContent>
+                                    <Divider />
+                                    <CardActions>
+                                        {editMode ? (
+                                            <Button
+                                                color="primary"
+                                                variant="contained"
+                                                disabled={!resonator.done}
+                                                onClick={() => setEditMode(false)}
+                                            >
+                                                Finish
+                                            </Button>
+                                        ) : (
+                                            <Button color="primary" onClick={() => setEditMode(true)}>
+                                                Edit answers
+                                            </Button>
+                                        )}
+                                    </CardActions>
+                                </>
+                            ) : null}
+                        </Card>
+                    </div>
                 </Grow>
             ) : null}
         </>

--- a/src/components/followers/SentResonator.js
+++ b/src/components/followers/SentResonator.js
@@ -1,6 +1,6 @@
 import { useSnackbar } from "notistack";
+import { useHistory } from "react-router";
 import React, { useEffect, useState } from "react";
-import { useParams, useHistory } from "react-router";
 import { Link as LinkIcon, Close } from "@material-ui/icons";
 import {
     makeStyles,
@@ -50,10 +50,9 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-export default function SentResonator() {
+export default function SentResonator({ sentResonatorId }) {
     const classes = useStyles();
     const history = useHistory();
-    const { sentResonatorId } = useParams();
     const { enqueueSnackbar } = useSnackbar();
 
     const [loading, setLoading] = useState(true);


### PR DESCRIPTION
### Made links truncate instead of wrapping
Before:
![image](https://user-images.githubusercontent.com/65984816/90788208-3cf5a400-e30e-11ea-8ad2-0baf4c8dad56.png)
After:
![image](https://user-images.githubusercontent.com/65984816/90788283-54cd2800-e30e-11ea-9914-cdc1ded09336.png)

### Made the questionnaire automatically progress to the next question, if the question was answered for the first time
![autoprogress](https://user-images.githubusercontent.com/65984816/90788830-dd4bc880-e30e-11ea-92fc-9445b60cf3a4.gif)

### Added a CLOSE button for resonators
![image](https://user-images.githubusercontent.com/65984816/90788950-fd7b8780-e30e-11ea-873e-af81353ae84b.png)

### And also made resonators open from within the overview page, which means the resonator list is only loaded once (not every time you return to it)