### PR TITLE
Changed member count badge back to typography

### DIFF
--- a/src/components/FollowerGroups.js
+++ b/src/components/FollowerGroups.js
@@ -113,13 +113,10 @@ class FollowerGroups extends Component {
                 title: "Add/Remove Members",
                 icon: (followerGroupId) => (
                     <React.Fragment>
-                        <Badge
-                            badgeContent={this.props.getFollowerGroup(followerGroupId).memberCount}
-                            color="primary"
-                            style={isMobile(this.props.width) ? { top: 7 } : {}}
-                        >
-                            <Group color='primary' />
-                        </Badge>
+                        <Typography color='primary' style={{ marginRight: !isMobile(this.props.width) && '0.5vw' }}>
+                            ({this.props.getFollowerGroup(followerGroupId).memberCount})
+                        </Typography>
+                        <Group color='primary' />
                     </React.Fragment>
                 ),
                 onClick: (followerGroupId) => this.props.push(this.getMembersRoute(followerGroupId)),


### PR DESCRIPTION
Requested to revert to typography which is clearer than the badge for displaying a group's member count 

![image](https://user-images.githubusercontent.com/35032128/92521835-945ca500-f226-11ea-9c79-fc6c5f95f742.png)
