### PR TITLE
restored exludedRedirect in session resume.

### DIFF
--- a/src/components/login/LoginForm.js
+++ b/src/components/login/LoginForm.js
@@ -13,11 +13,11 @@ import { actions as navigationActions } from "../../actions/navigationActions";
 const isLoginFormRequired = false;
 
 class LoginForm extends Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         this.state = {
-            isLeader: false
+            isLeader: props.isLeaderPage
         };
 
         this.handleGoogleLogin = this.handleGoogleLogin.bind(this);
@@ -37,13 +37,13 @@ class LoginForm extends Component {
         let google_error_message = '';
         switch(this.props.errorGoogle) { // this should probably be replaced by key-based translations later
             case 'not_leader':
-                google_error_message = 'This user is not registered as a Leader. Contact your Leader';
+                google_error_message = 'This user is not registered as a Leader.';
             break;
             case 'not_follower':
-                google_error_message = 'This user is not registered as a Follower';
+                google_error_message = 'System cannot find a Follower record for this user. Please contact your Leader.';
                 break;
             case 'follower_registration_not_allowed':
-                google_error_message = 'Can\'t register as a follower. Follower needs to be assigned to a leader';
+                google_error_message = 'Can\'t register as a follower. Please contact your Leader.';
             break;
             case 'unknown':
                 google_error_message = 'Unknown problem. Try again';

--- a/src/sagas/sessionSaga.js
+++ b/src/sagas/sessionSaga.js
@@ -18,12 +18,16 @@ let {handle, updateState, saga, reducer} = SagaReducerFactory({
 
 handle(types.RESUME, function*() {
     try {
-        let user = yield call(sessionApi.get);
-        let loggedIn = yield updateUser(user);
+        const user = yield call(sessionApi.get);
+        const loggedIn = yield updateUser(user);
         const currentPath = location.pathname;
+        const excludedRedirect = [ // Need this to keep the query params (Google auth errors)
+            '/login',
+            '/loginLeader'
+        ];
 
-        if (!loggedIn)
-            yield put(navigationActions.navigate((currentPath === '/followers' || currentPath === '/loginLeader') ? 'loginLeader' : 'login'));
+        if (!loggedIn && !excludedRedirect.includes(currentPath))
+            yield put(navigationActions.navigate((currentPath === '/followers') ? 'loginLeader' : 'login'));
     } catch (err) {
         console.log('resuming session failed', err);
         yield put(navigationActions.navigate('login'));


### PR DESCRIPTION
Need this to keep the query params (used for Google Auth errors), they're discarded otherwise. Seems like the least intrusive way.
Also the Leader Login form now starts in Leader mode by default. Updated the error text as well